### PR TITLE
Add runtime tests

### DIFF
--- a/e2e-tests/js_scripts/0005-proofPath_rpc.js
+++ b/e2e-tests/js_scripts/0005-proofPath_rpc.js
@@ -10,8 +10,8 @@
 const Keccak256 = require('keccak256')
 
 // Hardcoded proof hashes
-proof_01 = "0x283e3f25323d02dabdb94a897dc2697a3b930d8781381ec574af89a201a91d5a2c2808c59f5c736ff728eedfea58effc2443722e78b2eb4e6759a278e9246d600f9c56dc88e043ce0b90c402e96b1f4b1a246f4d0d69a4c340bc910e1f2fd80519e465e01bd7629f175931feed102cb6459a1be7b08018b93c142e961d0352d80b8e5d340df28c2f454c5a2535ca01a230bb945ee24b1171481a9a2c6496fed61cf8878e40adb52dc27da5e79718f118467319d15d64fed460d69d951376ac631a6c44faaec76e296b43fe720d700a63fd530f9064878b5f72f2ffe7458c2f031ac6ed8c1e0758dfb3702ed29bbc0c14b5e727c164b3ade07b9f164af0be54b0143b1a6534b2dcf2bd660e1b5b420d86c0c350fd9d614b639c5df98009f1375e141259679021d0a6a3aa3aae2516bace4a4a651265217ec0ea7c0d7f89b987100abcc93d98ff40bae16eff6c29955f7a37155bb25672b12eb5074dcb7c3e2b001718a257cca21ee593d1ba9f8e91e5168aed8e0b1893e11a6b583d975e747f8008a8c2150a04d8f867945ca1740dc3fc3b2fc4daff61b4725fb294435a1b90101803690ae70fc212b7e929de9a22a4642ef4772546cf93ffd1b1196a3d9113a3009c506755578932ca3630508ca1ed6ee83df5ec9e26cb0b5800a70967a1a93a04d142b6a532935a31d84f75d16929df6d38c3a210ac4f435a8024dfb7e6c1f3246d58038a943f237325b44f03d106e523adfec4324615a2dd09e1e5b9143b411c1cf09ee411cf9864d30df4904099920cee9ae8134d45dfeb29e46115d2e740098674b8fc2ca31fac6fcc9302860654fdc1b522b7e064b0759bc5924f332fa921121b5af880f83fbce02f19dabb8f684593e7322fb80bfc0d054797b1d4eff411b01bf68f81f2032ae4f7fc514bd76ca1b264f3989a92e6b3d74cda4f8a714920e4c02f5a71082a8bcf5be0b5750a244bd040a776ec541dfc2c8ae73180e9240ada5414d66387211eec80d7d9d48498efa1e646d64bb1bf8775b3796a9fd0bf0fdf8244018ce57b018c093e2f75ed77d8dbdb1a7b60a2da671de2efe5f6b9d70d69b94acdfaca5bacc248a60b35b925a2374644ce0c1205db68228c8921d9d9"
-proof_02 = "0x2ecc31435ec6d6963d463c38ea5662d9c94a67e441e7bc611598ebcc59f571880768291fd5d95fcf02bce7e4fde1f048b843bbffab1f242904e82d443a4ebb61150c3a4afdbb62d034320da390e3585a30ba13f4df73798b78e5a75655d3350d19fca02cc5838405f9ae4177ac7117971af2cb5006d7a46436f644410d6e7c52099f803c0f18d4b44fe22f3100d1fc80ccb7309fa7168f51bc64f3fc0f1dbd240b0573f3593238e56b23e75246d9d0f6f6a5cf824700667e3482ca9fecf74cdc0b308e6a8f69dccb9ca00d540543441f7030928da766406a152427bdf31b44051b6b5198b34006f9ac34c6c857e450cc11f5c6b6d21119fe283738581c0ad8bd0f8cbdbc574f64da884f6a02e00669f3eef10138266f3d7fa278aef1b1c60171005c0c2b8b2429c5003c5ab24af44cb1ab81cdc96dcaf6004a0f74406bb10f45233b13015cef8c40c491a7770efd0a8d8a64186d4f3827e74972bfc25b11f1f002550a5e253c923c5783026c7439601595477f1a212de449c64a8ae5e2fc0313127bf9cd5146217e531196ce65ccef3249375450d6932151f923c39e6a73588223d90f5bf230eee5a6cb6463f161602cc37fe538e2954ebef695b926b76e3fae299c60c1952aa4b1f246204ac7c22c0156ede30aeb73444ee40d69c0f131fa471fdca090abfd38541c88ee73624657a695155748643f7834b80d1c0481079e670033817252b24575a4e6007f08f37c34462d5e9fd50b1e83ec8cfc86149400d519e224ee11831ac393e3a09730be6f385ae5c9e14446fde5069fea751fb6b48211c85268b8017de7981eb1bd78526bc20d5f863ad3abe249728ca7b75b2146c1254465d6100a911213d95f800779e74f6701b1dfa0b6660642108fd2c7cd2f131d9163eeebe9d8aabdf8d37fde4451f762be478d117688e0a6ed2648dbe025e82a4b13ee629a73d1efa6f269747506058746aa589bb961c1385bb2b30e0086f010ef87535f2137a04f19fe5aa7c4f348c32ce6f5b0b45bb503895673a8a51d7f1b0228693fbfb38be718b04c9fdf116a97d7f30e670db84d21bb0d12fc57645415950a3fab52ee1557ac7b895deeca2eb27bacfc3b9e26a39b1875149680611d"
+const proof_01 = "0x283e3f25323d02dabdb94a897dc2697a3b930d8781381ec574af89a201a91d5a2c2808c59f5c736ff728eedfea58effc2443722e78b2eb4e6759a278e9246d600f9c56dc88e043ce0b90c402e96b1f4b1a246f4d0d69a4c340bc910e1f2fd80519e465e01bd7629f175931feed102cb6459a1be7b08018b93c142e961d0352d80b8e5d340df28c2f454c5a2535ca01a230bb945ee24b1171481a9a2c6496fed61cf8878e40adb52dc27da5e79718f118467319d15d64fed460d69d951376ac631a6c44faaec76e296b43fe720d700a63fd530f9064878b5f72f2ffe7458c2f031ac6ed8c1e0758dfb3702ed29bbc0c14b5e727c164b3ade07b9f164af0be54b0143b1a6534b2dcf2bd660e1b5b420d86c0c350fd9d614b639c5df98009f1375e141259679021d0a6a3aa3aae2516bace4a4a651265217ec0ea7c0d7f89b987100abcc93d98ff40bae16eff6c29955f7a37155bb25672b12eb5074dcb7c3e2b001718a257cca21ee593d1ba9f8e91e5168aed8e0b1893e11a6b583d975e747f8008a8c2150a04d8f867945ca1740dc3fc3b2fc4daff61b4725fb294435a1b90101803690ae70fc212b7e929de9a22a4642ef4772546cf93ffd1b1196a3d9113a3009c506755578932ca3630508ca1ed6ee83df5ec9e26cb0b5800a70967a1a93a04d142b6a532935a31d84f75d16929df6d38c3a210ac4f435a8024dfb7e6c1f3246d58038a943f237325b44f03d106e523adfec4324615a2dd09e1e5b9143b411c1cf09ee411cf9864d30df4904099920cee9ae8134d45dfeb29e46115d2e740098674b8fc2ca31fac6fcc9302860654fdc1b522b7e064b0759bc5924f332fa921121b5af880f83fbce02f19dabb8f684593e7322fb80bfc0d054797b1d4eff411b01bf68f81f2032ae4f7fc514bd76ca1b264f3989a92e6b3d74cda4f8a714920e4c02f5a71082a8bcf5be0b5750a244bd040a776ec541dfc2c8ae73180e9240ada5414d66387211eec80d7d9d48498efa1e646d64bb1bf8775b3796a9fd0bf0fdf8244018ce57b018c093e2f75ed77d8dbdb1a7b60a2da671de2efe5f6b9d70d69b94acdfaca5bacc248a60b35b925a2374644ce0c1205db68228c8921d9d9"
+const proof_02 = "0x2ecc31435ec6d6963d463c38ea5662d9c94a67e441e7bc611598ebcc59f571880768291fd5d95fcf02bce7e4fde1f048b843bbffab1f242904e82d443a4ebb61150c3a4afdbb62d034320da390e3585a30ba13f4df73798b78e5a75655d3350d19fca02cc5838405f9ae4177ac7117971af2cb5006d7a46436f644410d6e7c52099f803c0f18d4b44fe22f3100d1fc80ccb7309fa7168f51bc64f3fc0f1dbd240b0573f3593238e56b23e75246d9d0f6f6a5cf824700667e3482ca9fecf74cdc0b308e6a8f69dccb9ca00d540543441f7030928da766406a152427bdf31b44051b6b5198b34006f9ac34c6c857e450cc11f5c6b6d21119fe283738581c0ad8bd0f8cbdbc574f64da884f6a02e00669f3eef10138266f3d7fa278aef1b1c60171005c0c2b8b2429c5003c5ab24af44cb1ab81cdc96dcaf6004a0f74406bb10f45233b13015cef8c40c491a7770efd0a8d8a64186d4f3827e74972bfc25b11f1f002550a5e253c923c5783026c7439601595477f1a212de449c64a8ae5e2fc0313127bf9cd5146217e531196ce65ccef3249375450d6932151f923c39e6a73588223d90f5bf230eee5a6cb6463f161602cc37fe538e2954ebef695b926b76e3fae299c60c1952aa4b1f246204ac7c22c0156ede30aeb73444ee40d69c0f131fa471fdca090abfd38541c88ee73624657a695155748643f7834b80d1c0481079e670033817252b24575a4e6007f08f37c34462d5e9fd50b1e83ec8cfc86149400d519e224ee11831ac393e3a09730be6f385ae5c9e14446fde5069fea751fb6b48211c85268b8017de7981eb1bd78526bc20d5f863ad3abe249728ca7b75b2146c1254465d6100a911213d95f800779e74f6701b1dfa0b6660642108fd2c7cd2f131d9163eeebe9d8aabdf8d37fde4451f762be478d117688e0a6ed2648dbe025e82a4b13ee629a73d1efa6f269747506058746aa589bb961c1385bb2b30e0086f010ef87535f2137a04f19fe5aa7c4f348c32ce6f5b0b45bb503895673a8a51d7f1b0228693fbfb38be718b04c9fdf116a97d7f30e670db84d21bb0d12fc57645415950a3fab52ee1557ac7b895deeca2eb27bacfc3b9e26a39b1875149680611d"
 
 // Custom types and RPC calls
 // This one defines the metadata for the return value of proofPath RPC call
@@ -24,6 +24,21 @@ newTypes = {
         leaf: 'H256',
     }
 };
+
+const BlockUntil = {
+    InBlock: 'InBlock',
+    Finalized: 'Finalized',
+};
+
+const ReturnCode = {
+    Ok: 1,
+    ErrProofVerificationFailed: 2,
+    ErrNoAttestation: 3,
+    ErrAttProofVerificationFailed: 4,
+    ErrWrongAttestationTiming: 5,
+};
+
+const BLOCK_TIME = 6000; // block time in milliseconds
 
 // This one defines the metadata for the arguments and return value of proofPath RPC call
 userDefinedRpc = {
@@ -70,30 +85,38 @@ async function run(nodeName, networkInfo, args) {
     const proof_1_submission = api.tx.settlementFFlonkPallet.submitProof(proof_01);
     const proof_2_submission = api.tx.settlementFFlonkPallet.submitProof(proof_02);
     // ...and submit them
-    const hash01 = await submit_an_extrinsic(proof_1_submission, alice);
-    const hash02 = await submit_an_extrinsic(proof_2_submission, alice);
+    const hash01 = await submit_an_extrinsic(proof_1_submission, alice, BlockUntil.InBlock);
+    const proof_included_timestamp = Date.now();
+    const hash02 = await submit_an_extrinsic(proof_2_submission, alice, BlockUntil.InBlock);
+
     // Save the proof hash only if the extrinsic has been successfully included in a block
-    if (hash01 != -1) {
-        proof_hashes_array.push(hash01);
-    }
-    if (hash02 != -1) {
-        proof_hashes_array.push(hash02);
-    }
     if (hash01 == -1 || hash02 == -1) {
-        return 2;
+        return ReturnCode.ErrProofVerificationFailed;
     }
+    proof_hashes_array.push(hash01);
+    proof_hashes_array.push(hash02);
 
     // Wait for the next attestation ID to be emitted
-    const interesting_att_id = await wait_for_new_attestation(api);
+    const expected_att_timeout = BLOCK_TIME * 10;
+    const expected_att_timeout_delta = BLOCK_TIME * 2;
+    const interesting_att_id = await wait_for_new_attestation(api, expected_att_timeout * 2);
+    const att_timestamp = Date.now();
     if (interesting_att_id == -1) {
         console.log("Something went wrong while waiting for a new attestation");
-        return 3;
+        return ReturnCode.ErrNoAttestation;
     } else {
         var published_root = interesting_att_id.data[1];
         console.log("A new attestation has been published: ");
         interesting_att_id.data.forEach((data) => {
             console.log(`\t\t\t${data.toString()}`);
         });
+    }
+
+    // Check that the attestation was received in the expected time window
+    if (att_timestamp < proof_included_timestamp + expected_att_timeout ||
+        att_timestamp > proof_included_timestamp + (expected_att_timeout + expected_att_timeout_delta)) {
+        console.log("Attestation not received in the expected time window");
+        return ReturnCode.ErrWrongAttestationTiming;
     }
 
     // For each proof, get its Merkle path and evaluate the root
@@ -108,20 +131,20 @@ async function run(nodeName, networkInfo, args) {
     const proof_01_verification = await verify_proof(poe_res01, published_root);
     console.log("Proof 01 verification: " + proof_01_verification);
     if (!proof_01_verification) {
-        return 4;
+        return ReturnCode.ErrAttProofFailedVerification;
     }
 
     const proof_02_verification = await verify_proof(poe_res02, published_root);
     console.log("Proof 02 verification: " + proof_02_verification);
     if (!proof_02_verification) {
-        return 4;
+        return ReturnCode.ErrAttProofFailedVerification;
     }
 
     // Any return value different from 1 is considered an error
-    return 1;
+    return ReturnCode.Ok;
 }
 
-async function submit_an_extrinsic(extrinsic, signer) {
+async function submit_an_extrinsic(extrinsic, signer, block_until) {
     let transaction_success_event = false;
 
     let ret_val = await new Promise( async (resolve, reject) => {
@@ -142,15 +165,25 @@ async function submit_an_extrinsic(extrinsic, signer) {
                         proof_hash = data[0].toString();
                     }
                 });
+                if (block_until === BlockUntil.InBlock) {
+                    unsub();
+                    if (transaction_success_event) {
+                        resolve(proof_hash);
+                    } else {
+                        reject("ExtrinsicSuccess has not been seen");
+                    }
+                }
             }
 
             else if (status.isFinalized) {
                 console.log(`Transaction finalized at blockhash ${status.asFinalized}`);
-                unsub();
-                if (transaction_success_event) {
-                    resolve(proof_hash);
-                } else {
-                    reject("ExtrinsicSuccess has not been seen");
+                if (block_until === BlockUntil.Finalized) {
+                    unsub();
+                    if (transaction_success_event) {
+                        resolve(proof_hash);
+                    } else {
+                        reject("ExtrinsicSuccess has not been seen");
+                    }
                 }
             }
 
@@ -162,7 +195,7 @@ async function submit_an_extrinsic(extrinsic, signer) {
     })
     .then(
         (proof_hash) => {
-            console.log("Transaction successfully finalized and included in a block" + proof_hash)
+            console.log("Transaction successfully processed: " + proof_hash)
             return proof_hash;
         },
         error => {
@@ -174,10 +207,11 @@ async function submit_an_extrinsic(extrinsic, signer) {
 }
 
 // Wait for the next attestaion id to be published
-async function wait_for_new_attestation(api) {
+async function wait_for_new_attestation(api, timeout) {
 
     const ret_val = await new Promise( async (resolve, reject) => {
         // Subscribe to system events via storage
+        timeout = setTimeout(function() { unsubscribe(); reject("Timeout expired"); }, timeout);
         const unsubscribe = await api.query.system.events((events) => {
             console.log(`\nReceived ${events.length} events:`);
 
@@ -191,6 +225,7 @@ async function wait_for_new_attestation(api) {
                 console.log(`\t${event.section}:${event.method}:: (phase=${phase.toString()})`);
 
                 if ((event.section == "poe") && (event.method == "NewAttestation")) {
+                    clearTimeout(timeout);
                     unsubscribe();
                     resolve(event);
                 }

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -15,10 +15,30 @@
 
 use super::*;
 
-use frame_support::traits::{fungible::Inspect, Currency, ExistenceRequirement, WithdrawReasons};
+use codec::Encode;
+use frame_support::{
+    assert_ok,
+    traits::{fungible::Inspect, Currency, ExistenceRequirement, OnInitialize, WithdrawReasons},
+};
+use frame_system::{EventRecord, Phase};
 use pallet_settlement_fflonk::{Proof, FULL_PROOF_SIZE};
+use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
+use sp_core::{Pair, Public};
+use sp_runtime::{AccountId32, Digest, DigestItem};
+use sp_staking::{offence, offence::ReportOffence, Exposure, SessionIndex};
 
 mod testsfixtures;
+
+/// Generate a crypto pair from seed.
+pub fn get_from_seed<TPublic: Public>(seed: u8) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(&format!("//test_seed{}", seed), None)
+        .expect("static values are valid; qed")
+        .public()
+}
+
+pub const SLOT_ID: u64 = 87; // Any random value should do
+pub const NUM_VALIDATORS: u32 = 2;
+pub const AURA_AUTHOR_ID: u32 = (SLOT_ID as u32) % NUM_VALIDATORS;
 
 // Function used for creating the environment for the test.
 // It must return a sp_io::TestExternalities, and the actual test will execute this one before running.
@@ -28,15 +48,62 @@ fn new_test_ext() -> sp_io::TestExternalities {
         .build_storage()
         .unwrap();
 
-    // Create four users by calling the fixture function
-    let sample_users = testsfixtures::get_sample_users();
-
-    // Incorporate the pairs account / starting balance into the Genesis config
     pallet_balances::GenesisConfig::<super::Runtime> {
-        balances: sample_users
+        balances: testsfixtures::SAMPLE_USERS
+            .to_vec()
             .into_iter()
             .map(|user| (user.raw_account.into(), user.starting_balance))
             .collect(),
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    // Add authorities
+    pallet_session::GenesisConfig::<super::Runtime> {
+        keys: testsfixtures::SAMPLE_USERS
+            .to_vec()
+            .into_iter()
+            .map(|user| {
+                (
+                    user.raw_account.into(),
+                    user.raw_account.into(),
+                    SessionKeys {
+                        aura: get_from_seed::<AuraId>(user.session_key_seed),
+                        grandpa: get_from_seed::<GrandpaId>(user.session_key_seed),
+                        im_online: get_from_seed::<ImOnlineId>(user.session_key_seed),
+                    },
+                )
+            })
+            .take(NUM_VALIDATORS as usize)
+            .collect(),
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    pallet_staking::GenesisConfig::<super::Runtime> {
+        stakers: testsfixtures::SAMPLE_USERS
+            .to_vec()
+            .into_iter()
+            .map(|user| {
+                (
+                    user.raw_account.into(),
+                    user.raw_account.into(),
+                    testsfixtures::STASH_DEPOSIT,
+                    sp_staking::StakerStatus::Validator::<AccountId>,
+                )
+            })
+            .take(NUM_VALIDATORS as usize)
+            .collect(),
+        minimum_validator_count: NUM_VALIDATORS,
+        validator_count: NUM_VALIDATORS,
+        canceled_payout: 0,
+        force_era: pallet_staking::Forcing::ForceNone,
+        invulnerables: [].to_vec(),
+        max_nominator_count: None,
+        max_validator_count: None,
+        min_nominator_bond: 1,
+        min_validator_bond: testsfixtures::STASH_DEPOSIT,
+        slash_reward_fraction: Perbill::zero(),
     }
     .assimilate_storage(&mut t)
     .unwrap();
@@ -54,9 +121,8 @@ fn new_test_ext() -> sp_io::TestExternalities {
 fn check_starting_balances_and_existential_limit() {
     new_test_ext().execute_with(|| {
         // This creates a few public keys used to be converted to AccountId
-        let sample_users = testsfixtures::get_sample_users();
 
-        for sample_user in &sample_users {
+        for sample_user in &testsfixtures::SAMPLE_USERS {
             assert_eq!(
                 Balances::balance(&sample_user.raw_account.into()),
                 sample_user.starting_balance
@@ -66,14 +132,17 @@ fn check_starting_balances_and_existential_limit() {
         // Now perform a withdraw on the fourth account, leaving its balance under the EXISTENTIAL_DEPOSIT limit
         // This should kill the account, when executed with the ExistenceRequirement::AllowDeath option
         let _id_3_withdraw = Balances::withdraw(
-            &sample_users[3].raw_account.into(),
-            testsfixtures::EXISTENTIAL_DEPOSIT_REMINDER, // Withdrawing more th
+            &testsfixtures::SAMPLE_USERS[3].raw_account.into(),
+            testsfixtures::EXISTENTIAL_DEPOSIT_REMAINDER, // Withdrawing more th
             WithdrawReasons::TIP,
             ExistenceRequirement::AllowDeath,
         );
 
         // Verify that the fourth account balance is now 0
-        assert_eq!(Balances::balance(&sample_users[3].raw_account.into()), 0);
+        assert_eq!(
+            Balances::balance(&testsfixtures::SAMPLE_USERS[3].raw_account.into()),
+            0
+        );
     });
 }
 
@@ -81,7 +150,7 @@ fn check_starting_balances_and_existential_limit() {
 #[test]
 fn pallet_fflonk_availability() {
     new_test_ext().execute_with(|| {
-        let dummy_origin = sp_runtime::AccountId32::new([0; 32]);
+        let dummy_origin = AccountId32::new([0; 32]);
         let dummy_raw_proof: Proof = [0; FULL_PROOF_SIZE];
         assert!(SettlementFFlonkPallet::submit_proof(
             RuntimeOrigin::signed(dummy_origin),
@@ -96,7 +165,190 @@ fn pallet_fflonk_availability() {
 #[test]
 fn pallet_poe_availability() {
     new_test_ext().execute_with(|| {
-        assert!(Poe::publish_attestation(RuntimeOrigin::root()).is_ok());
+        assert_ok!(Poe::publish_attestation(RuntimeOrigin::root()));
         // just checking code builds, hence the pallet is available to the runtime
     });
+}
+
+mod pallets_interact {
+    use super::*;
+
+    #[test]
+    fn session_notifies_staking() {
+        new_test_ext().execute_with(|| {
+            let pre_staking_session = Staking::current_planned_session();
+            Session::rotate_session();
+            let post_staking_session = Staking::current_planned_session();
+            assert_eq!(pre_staking_session + 1, post_staking_session);
+        });
+    }
+
+    mod authorship {
+        use super::*;
+        const BLOCK_NUMBER: BlockNumber = 1;
+
+        fn initialize() {
+            let slot = Slot::from(SLOT_ID);
+            let pre_digest = Digest {
+                logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+            };
+            System::reset_events();
+            System::initialize(&BLOCK_NUMBER, &Default::default(), &pre_digest);
+        }
+
+        #[test]
+        fn authorship_is_configured_with_aura() {
+            new_test_ext().execute_with(|| {
+                initialize();
+                assert_eq!(
+                    Authorship::author(),
+                    Some(AccountId32::new(
+                        testsfixtures::SAMPLE_USERS[AURA_AUTHOR_ID as usize]
+                            .raw_account
+                            .into()
+                    ))
+                );
+            });
+        }
+
+        // Check that Authorship calls back on ImOnline
+        #[test]
+        fn authorship_notifies_imonline() {
+            new_test_ext().execute_with(|| {
+                initialize();
+                assert!(!ImOnline::is_online(AURA_AUTHOR_ID));
+                Authorship::on_initialize(BLOCK_NUMBER);
+                assert!(ImOnline::is_online(AURA_AUTHOR_ID));
+            });
+        }
+
+        #[test]
+        fn authorship_notifies_staking() {
+            new_test_ext().execute_with(|| {
+                initialize();
+                // Before authoring a block, no points have been given in the active era
+                assert!(
+                    Staking::eras_reward_points(
+                        Staking::active_era().expect("No active era").index
+                    )
+                    .total
+                        == 0
+                );
+
+                // Pretend we author a block
+                Authorship::on_initialize(BLOCK_NUMBER);
+
+                // Authoring a block notifies Staking, which results in a positive points balance
+                assert!(
+                    Staking::eras_reward_points(
+                        Staking::active_era().expect("No active era").index
+                    )
+                    .total
+                        > 0
+                );
+            });
+        }
+    }
+
+    fn is_offender(session: SessionIndex, offender_account: &AccountId) -> bool {
+        pallet_offences::ConcurrentReportsIndex::<Runtime>::get(
+            b"im-online:offlin",
+            session.encode(),
+        )
+        .into_iter()
+        .any(|offender| {
+            pallet_offences::Reports::<Runtime>::get(offender)
+                .expect("Offence not found")
+                .offender
+                .0
+                == *offender_account
+        })
+    }
+
+    #[test]
+    fn imonline_notifies_offences() {
+        new_test_ext().execute_with(|| {
+            let session = Session::current_index();
+            let offender_account = AccountId32::new(
+                testsfixtures::SAMPLE_USERS[AURA_AUTHOR_ID as usize]
+                    .raw_account
+                    .into(),
+            );
+
+            // Check that no previous offences were reported
+            assert!(!is_offender(session, &offender_account));
+
+            // AURA_AUTHOR_ID is considered offline
+            assert!(!ImOnline::is_online(AURA_AUTHOR_ID));
+
+            // Advance to next session
+            System::set_block_number(System::block_number() + 1);
+            Session::rotate_session();
+
+            // Check that the offline offence for the last session was received by pallet_offences
+            assert!(is_offender(session, &offender_account));
+        });
+    }
+
+    pub const TEST_SLASH_FRACTION: Perbill = Perbill::one();
+    struct TestOffence {
+        offender_account: AccountId32,
+    }
+    impl offence::Offence<(AccountId32, Exposure<AccountId32, u128>)> for TestOffence {
+        const ID: offence::Kind = *b"testoffencenooop";
+        type TimeSlot = u128;
+
+        fn offenders(&self) -> Vec<(AccountId32, Exposure<AccountId32, u128>)> {
+            let exposure =
+                pallet_staking::EraInfo::<Runtime>::get_full_exposure(0, &self.offender_account);
+
+            vec![(self.offender_account.clone(), exposure)]
+        }
+        fn validator_set_count(&self) -> u32 {
+            NUM_VALIDATORS
+        }
+        fn time_slot(&self) -> Self::TimeSlot {
+            0
+        }
+        fn session_index(&self) -> SessionIndex {
+            0
+        }
+        fn slash_fraction(&self, _offenders_count: u32) -> Perbill {
+            TEST_SLASH_FRACTION
+        }
+    }
+
+    #[test]
+    fn offences_notifies_staking() {
+        new_test_ext().execute_with(|| {
+            let offender_account = sp_runtime::AccountId32::new(
+                testsfixtures::SAMPLE_USERS[AURA_AUTHOR_ID as usize]
+                    .raw_account
+                    .into(),
+            );
+
+            let expected_slashing_event = EventRecord {
+                phase: Phase::Initialization,
+                event: RuntimeEvent::Staking(pallet_staking::Event::SlashReported {
+                    validator: offender_account.clone(),
+                    fraction: TEST_SLASH_FRACTION,
+                    slash_era: 0,
+                }),
+                topics: vec![],
+            };
+
+            // Make sure that no slash events for offender_account is published
+            assert!(!System::events().contains(&expected_slashing_event));
+
+            // Make pallet_offences report an offence
+            let offence = TestOffence {
+                offender_account: offender_account.clone(),
+            };
+            assert_ok!(Offences::report_offence(vec![], offence));
+
+            // Check that pallet_staking generates the related event (i.e. it has been notified of
+            // the offence)
+            assert!(System::events().contains(&expected_slashing_event));
+        });
+    }
 }

--- a/runtime/src/tests/testsfixtures.rs
+++ b/runtime/src/tests/testsfixtures.rs
@@ -13,45 +13,53 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// Existential deposit used in pallet_balances
-pub const EXISTENTIAL_DEPOSIT: u128 = 500;
-pub const EXISTENTIAL_DEPOSIT_REMINDER: u128 = 1;
+use crate::Balance;
 
+// Existential deposit used in pallet_balances
+pub const EXISTENTIAL_DEPOSIT: Balance = 500;
+pub const EXISTENTIAL_DEPOSIT_REMAINDER: Balance = 1;
+pub const NUM_TEST_ACCOUNTS: u32 = 4;
+pub const STASH_DEPOSIT: Balance = 500; // MUST not be smaller than EXISTENTIAL_DEPOSIT
+
+#[derive(Clone)]
 pub struct SampleAccount {
     pub raw_account: [u8; 32],
-    pub starting_balance: u128,
+    pub starting_balance: Balance,
+    pub session_key_seed: u8,
 }
 
 // Build a vector containing a few sample user accounts, along with their starting balances
-pub fn get_sample_users() -> Vec<SampleAccount> {
-    vec![
-        SampleAccount {
-            raw_account: [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1,
-            ],
-            starting_balance: 1000001,
-        },
-        SampleAccount {
-            raw_account: [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 2,
-            ],
-            starting_balance: 12345432,
-        },
-        SampleAccount {
-            raw_account: [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 3,
-            ],
-            starting_balance: 9955223,
-        },
-        SampleAccount {
-            raw_account: [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 4,
-            ],
-            starting_balance: EXISTENTIAL_DEPOSIT,
-        },
-    ]
-}
+pub static SAMPLE_USERS: [SampleAccount; NUM_TEST_ACCOUNTS as usize] = [
+    SampleAccount {
+        raw_account: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ],
+        starting_balance: 1000001,
+        session_key_seed: 1,
+    },
+    SampleAccount {
+        raw_account: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 2,
+        ],
+        starting_balance: 12345432,
+        session_key_seed: 2,
+    },
+    SampleAccount {
+        raw_account: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 3,
+        ],
+        starting_balance: 9955223,
+        session_key_seed: 3,
+    },
+    SampleAccount {
+        raw_account: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 4,
+        ],
+        starting_balance: EXISTENTIAL_DEPOSIT,
+        session_key_seed: 4,
+    },
+];


### PR DESCRIPTION
This PR adds few runtime tests to check the correct configuration of several pallets (e.g. those involved with staking).
It also extends the proofPath E2E test to verify that the expected timeout is respected when publishing a new attestation after the submission of its first proof.