### PR TITLE
Set validators reward to 6.25 NZEN every 2.5 minutes

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -327,14 +327,22 @@ impl pallet_session::Config for Runtime {
 
 pub struct ZendPayout;
 impl pallet_staking::EraPayout<Balance> for ZendPayout {
+    /// Calculates the validators reward based on the duration of the era.
+    /// The reward mimics the current PoW coinbase (6.25 $ZEN per block).
+    /// Total stake and issuance are currently ignored.
     fn era_payout(
         _total_staked: Balance,
         _total_issuance: Balance,
         era_duration_millis: u64,
     ) -> (Balance, Balance) {
-        let era_reward: u128 = 625 * CENTS * u128::from(era_duration_millis / MILLISECS_PER_BLOCK); // 6.25nZEN per block
-        pub const TENTH_TO_MINERS: u128 = 10;
-        pub const TENTH_TO_REST: u128 = 0;
+        const HORIZEN_POW_MILLISECS_PER_BLOCK: u64 = 150 * 1000; // 2.5 minutes
+        let era_reward: u128 =
+            625 * CENTS * u128::from(era_duration_millis / HORIZEN_POW_MILLISECS_PER_BLOCK); // 6.25nZEN per block
+
+        // Assign 100% of the reward to validators.
+        // In the future we may want to split the reward between validators and the treasury.
+        const TENTH_TO_MINERS: u128 = 10;
+        const TENTH_TO_REST: u128 = 0;
 
         (
             era_reward * TENTH_TO_MINERS / 10,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -335,9 +335,9 @@ impl pallet_staking::EraPayout<Balance> for ZendPayout {
         _total_issuance: Balance,
         era_duration_millis: u64,
     ) -> (Balance, Balance) {
-        const HORIZEN_POW_MILLISECS_PER_BLOCK: u64 = 150 * 1000; // 2.5 minutes
+        const HORIZEN_POW_MILLISECS_PER_BLOCK: u128 = 150 * 1000; // 2.5 minutes
         let era_reward: u128 =
-            625 * CENTS * u128::from(era_duration_millis / HORIZEN_POW_MILLISECS_PER_BLOCK); // 6.25nZEN per block
+            625 * CENTS * u128::from(era_duration_millis) / HORIZEN_POW_MILLISECS_PER_BLOCK; // 6.25nZEN per Zend block
 
         // Assign 100% of the reward to validators.
         // In the future we may want to split the reward between validators and the treasury.

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -352,3 +352,31 @@ mod pallets_interact {
         });
     }
 }
+
+/// This module tests the correct computation of rewards for validators.
+mod payout {
+    use pallet_staking::EraPayout;
+
+    use crate::{Balance, Runtime, CENTS};
+
+    use super::new_test_ext;
+
+    /// Test that validators receive a cumulative reward that mimics the current emission of
+    /// $ZEN in the PoW Horizen blockchain for miners, which is a coinbase of 6.25 Zen for
+    /// each block every 2.5 minutes.
+    #[test]
+    fn payout_is_same_as_pow_coinbase() {
+        new_test_ext().execute_with(|| {
+            const POW_BLOCK_TIME_MILLIS: u64 = 150 * 1000;
+            const POW_BLOCK_COINBASE: Balance = 625 * CENTS;
+            assert_eq!(
+                <Runtime as pallet_staking::Config>::EraPayout::era_payout(
+                    0,
+                    0,
+                    POW_BLOCK_TIME_MILLIS
+                ),
+                (POW_BLOCK_COINBASE, 0)
+            );
+        });
+    }
+}

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -365,10 +365,12 @@ mod payout {
     /// $ZEN in the PoW Horizen blockchain for miners, which is a coinbase of 6.25 Zen for
     /// each block every 2.5 minutes.
     #[test]
-    fn payout_is_same_as_pow_coinbase() {
+    fn is_same_as_pow_coinbase() {
         new_test_ext().execute_with(|| {
             const POW_BLOCK_TIME_MILLIS: u64 = 150 * 1000;
             const POW_BLOCK_COINBASE: Balance = 625 * CENTS;
+
+            // Check the reward for an era lasting the target time.
             assert_eq!(
                 <Runtime as pallet_staking::Config>::EraPayout::era_payout(
                     0,
@@ -376,6 +378,22 @@ mod payout {
                     POW_BLOCK_TIME_MILLIS
                 ),
                 (POW_BLOCK_COINBASE, 0)
+            );
+
+            // Check the reward also for a smaller era (it should be proportional).
+            assert_eq!(
+                <Runtime as pallet_staking::Config>::EraPayout::era_payout(
+                    0,
+                    0,
+                    POW_BLOCK_TIME_MILLIS / 10
+                ),
+                (POW_BLOCK_COINBASE / 10, 0)
+            );
+
+            // Check the reward also for an empty era.
+            assert_eq!(
+                <Runtime as pallet_staking::Config>::EraPayout::era_payout(0, 0, 0),
+                (0, 0)
             );
         });
     }


### PR DESCRIPTION
The current reward mechanism is configured to mimic the coinbase emission on the PoW Horizen blockchain. The only difference is that here the reward is totally assigned to validators, while on Zend a part of the rewards goes to the miners and a small part to the treasury.