### PR TITLE
Changed ticker name. Updated balances and keys. Introduced inflation curve for era payouts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,6 +4526,7 @@ dependencies = [
  "pallet-session",
  "pallet-settlement-fflonk",
  "pallet-staking",
+ "pallet-staking-reward-curve",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -4933,6 +4934,18 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-staking-reward-curve"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca5a4a423427d2c83af5fe07ab648c16b91e3782c3cc23316fe0bd96b4c794"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5436,6 +5449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -9004,6 +9026,17 @@ dependencies = [
  "indexmap 2.2.5",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4938,11 +4938,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-curve"
-version = "11.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca5a4a423427d2c83af5fe07ab648c16b91e3782c3cc23316fe0bd96b4c794"
+checksum = "df8878e29f3d001ac1b1b714621f462e41a9d1fa8f385657f955e8a1ec0684d7"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -5449,15 +5449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.2",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -9026,17 +9017,6 @@ dependencies = [
  "indexmap 2.2.5",
  "serde",
  "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ pallet-im-online = { default-features = false, version = "26.0.0" }
 pallet-authorship = { default-features = false, version = "27.0.0" }
 pallet-session = { default-features = false, version = "27.0.0" }
 pallet-staking = { default-features = false, version = "27.0.0" }
-pallet-staking-reward-curve = { default-features = false, version = "11.0.0" }
+pallet-staking-reward-curve = { default-features = false, version = "10.0.0" }
 pallet-babe = { default-features = false, version = "27.0.0" }
 pallet-balances = { default-features = false, version = "27.0.0" }
 frame-support = { default-features = false, version = "27.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ pallet-im-online = { default-features = false, version = "26.0.0" }
 pallet-authorship = { default-features = false, version = "27.0.0" }
 pallet-session = { default-features = false, version = "27.0.0" }
 pallet-staking = { default-features = false, version = "27.0.0" }
+pallet-staking-reward-curve = { default-features = false, version = "11.0.0" }
 pallet-babe = { default-features = false, version = "27.0.0" }
 pallet-balances = { default-features = false, version = "27.0.0" }
 frame-support = { default-features = false, version = "27.0.0" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use nh_runtime::currency::{Balance, NZEN};
+use nh_runtime::currency::{Balance, ZETA};
 use nh_runtime::{currency, AccountId, RuntimeGenesisConfig, SessionKeys, Signature, WASM_BINARY};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_service::{ChainType, Properties};
@@ -28,7 +28,7 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
 
-const ENDOWMENT: Balance = 1_000_000 * NZEN;
+const ENDOWMENT: Balance = 1_000_000 * ZETA;
 const STASH_BOND: Balance = ENDOWMENT / 100;
 const DEFAULT_ENDOWED_SEEDS: [&str; 6] = ["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"];
 const LOCAL_N_AUTH: usize = 2;
@@ -117,7 +117,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
     .with_chain_type(ChainType::Development)
     .with_properties({
         let mut props = Properties::new();
-        props.insert("tokenSymbol".into(), "nZEN".into());
+        props.insert("tokenSymbol".into(), "ZETA".into());
         props.insert("tokenDecimals".into(), 18.into());
         props
     })
@@ -152,7 +152,7 @@ pub fn local_config() -> Result<ChainSpec, String> {
     .with_chain_type(ChainType::Local)
     .with_properties({
         let mut props = Properties::new();
-        props.insert("tokenSymbol".into(), "nZEN".into());
+        props.insert("tokenSymbol".into(), "ZETA".into());
         props.insert("tokenDecimals".into(), 18.into());
         props
     })
@@ -186,7 +186,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
     .with_chain_type(ChainType::Live)
     .with_properties({
         let mut props = Properties::new();
-        props.insert("tokenSymbol".into(), "nZEN".into());
+        props.insert("tokenSymbol".into(), "ZETA".into());
         props.insert("tokenDecimals".into(), 18.into());
         props
     })
@@ -196,26 +196,26 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
             // nh-validator-t1
             (
                 authority_ids_from_ss58(
-                    "5DkkLph1sMf13yZ2NJAQQAmW7v3gs7nq1Hq8VBzaz9qsnkTn",
-                    "5GLr2vfut1KixwPcqzmqg57zZ3bXgV3EisUCxA8Ws3eCiSwH",
+                    "5ETuZEyLnfVzQCaDM8aQCcsNnz6xjPKvQCtqynCLqwng8QLd",
+                    "5CbPYnSSw7KpKAJR3caCYv7KP3ChaAUgw5BgC3GPppnfiK5E",
                 )?,
-                4 * currency::MILLIONS,
+                280 * currency::MILLIONS,
             ),
             // nh-validator-t2
             (
                 authority_ids_from_ss58(
-                    "5FRPTHzWMtLiZPyf2YLnzeesLMscet8BBb4Khz14ftPxwFUj",
-                    "5H7fi3cWJkF4Mjm9cMm3umvB2QieZ2qwfZekJCb4LvaQVkN5",
+                    "5D29UEzgStCBTnjKNdkurDNvd3FHePHgTkPEUvjXYvg3brJj",
+                    "5H5XnaSsh5eebN2BSTx19qCUweMziyJATuUVb9qdWVDhHQ3K",
                 )?,
-                4 * currency::MILLIONS,
+                280 * currency::MILLIONS,
             ),
             // nh-validator-t3
             (
                 authority_ids_from_ss58(
-                    "5F9A9ktpR7pf5d3LQtppANSFfAXXzpGcCzYM5jBwfDBUpWZ6",
-                    "5Ep6w32bTWnPUMjyAVwEtrttmmjbM6Yo5vwP6gg79N74tPnw",
+                    "5DiMVAp8WmFyWAwaTwAr7sU4K3brXcgNCBDbHoBWj3M46PiP",
+                    "5CYcXe9bodJ31HE6pLT9EyUK5mrB3otXDNhDXVFSSmTAYm4f",
                 )?,
-                2 * currency::MILLIONS,
+                140 * currency::MILLIONS,
             ),
         ],
         // Sudo account [nh-sudo-t1]
@@ -225,63 +225,57 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         vec![
             // nh-validator-t1
             (
-                from_ss58check("5DkkLph1sMf13yZ2NJAQQAmW7v3gs7nq1Hq8VBzaz9qsnkTn")
+                from_ss58check("5ETuZEyLnfVzQCaDM8aQCcsNnz6xjPKvQCtqynCLqwng8QLd")
                     .map_err(|error| error.to_string())?,
-                4 * currency::MILLIONS + currency::NZEN,
+                280 * currency::MILLIONS + 1000 * currency::ZETA,
             ),
             // nh-validator-t2
             (
-                from_ss58check("5FRPTHzWMtLiZPyf2YLnzeesLMscet8BBb4Khz14ftPxwFUj")
+                from_ss58check("5D29UEzgStCBTnjKNdkurDNvd3FHePHgTkPEUvjXYvg3brJj")
                     .map_err(|error| error.to_string())?,
-                4 * currency::MILLIONS + currency::NZEN,
+                280 * currency::MILLIONS + 1000 * currency::ZETA,
             ),
             // nh-validator-t3
             (
-                from_ss58check("5F9A9ktpR7pf5d3LQtppANSFfAXXzpGcCzYM5jBwfDBUpWZ6")
+                from_ss58check("5DiMVAp8WmFyWAwaTwAr7sU4K3brXcgNCBDbHoBWj3M46PiP")
                     .map_err(|error| error.to_string())?,
-                2 * currency::MILLIONS + currency::NZEN,
+                140 * currency::MILLIONS + 1000 * currency::ZETA,
             ),
             // nh-sudo-t1
             (
-                from_ss58check("5D9txxK9DTvgCznTjJo7q1cxAgmWa83CzHvcz8zhBtLgaLBV")
+                from_ss58check("5EhREncHsntgJaax9YQphk1xN3LxPu2Rzbz4A3g7Ut8cRXWq")
                     .map_err(|error| error.to_string())?,
-                100 * currency::THOUSANDS,
+                7 * currency::MILLIONS,
             ),
             // nh-wallet-custody-t1
             (
-                from_ss58check("5GKWyvfHyK2PsbZEyTdh5BiP8rhizDaEs7ph2W9YokNLpwpM")
+                from_ss58check("5C84NU2477uHCUF1A8rHb89sP2D2ZsnquPaGa2Htv75FN9gm")
                     .map_err(|error| error.to_string())?,
-                currency::MILLIONS,
+                70 * currency::MILLIONS,
             ),
             // nh-wallet-custody-t2
             (
-                from_ss58check("5DnUTtZRaAbpYnwrdr7zme6snYeWXfQWJ5Rq253zUjJhd2fv")
+                from_ss58check("5HdZjrmNAkWQhYQUPNv7YRYnT4vyQswjbNm8eXBvULNQz5wH")
                     .map_err(|error| error.to_string())?,
-                currency::MILLIONS,
+                70 * currency::MILLIONS,
             ),
             // nh-wallet-automated-t1
             (
-                from_ss58check("5CkmKQbsvME3TZa6ULc7meNRRfrTNPU4aprMLymvFDMruJ9H")
+                from_ss58check("5HjFLKpiCStQgRm6ZM1fT1R5pLKAqQdUG3uh7pvzaQfhdFuB")
                     .map_err(|error| error.to_string())?,
-                500 * currency::THOUSANDS,
+                35 * currency::MILLIONS,
             ),
             // nh-wallet-user-t1
             (
-                from_ss58check("5HQRNiMdkVrhtEcrDcYD6K6FATYU13p9RKbN6iyu7kbgRN4u")
+                from_ss58check("5ECktCamcAtBFJirEzvvJmXFxgLMCTAejhqZwLT1Dxn2fwB1")
                     .map_err(|error| error.to_string())?,
-                100 * currency::THOUSANDS,
+                7 * currency::MILLIONS,
             ),
             // nh-wallet-faucet-t1
             (
-                from_ss58check("5FCFo9uuY5iZmBc4rE7wFeZcKf3gR8KujVVCPnib6H8XDHTM")
+                from_ss58check("5EZbvFqx3j7ejqBSPWseif8xL3PwoqMQHdMT8rs9qWoHcdR3")
                     .map_err(|error| error.to_string())?,
-                currency::MILLIONS,
-            ),
-            // cdk-aggregator-nh-t1
-            (
-                from_ss58check("5GCM2e4WzGPBy12xNZVc6XF72gund3esdRZAfAtGqiYCd697")
-                    .map_err(|error| error.to_string())?,
-                currency::MILLIONS,
+                70 * currency::MILLIONS,
             ),
         ],
         true,
@@ -337,7 +331,7 @@ mod tests {
     // by checking that the json returned by testnet_genesis() contains the field "session"
     #[test]
     fn testnet_genesis_should_set_session_keys() {
-        let initial_authorities = vec![(authority_keys_from_seed("Alice"), 7 * currency::NZEN)];
+        let initial_authorities = vec![(authority_keys_from_seed("Alice"), 7 * currency::ZETA)];
         let root_key = get_account_id_from_seed::<sr25519::Public>("Alice");
 
         let ret_val: serde_json::Value = genesis(initial_authorities, root_key, vec![], false);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ pallet-authorship = { workspace = true, default-features = false }
 pallet-session = { workspace = true, default-features = false }
 pallet-staking = { workspace = true, default-features = false }
 pallet-babe = { workspace = true, default-features = false }
+pallet-staking-reward-curve = { workspace = true, default-features = false }
 pallet-balances = { workspace = true, default-features = false }
 frame-support = { workspace = true, default-features = false }
 pallet-grandpa = { workspace = true, default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -87,9 +87,9 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 
 pub mod currency {
     pub type Balance = u128;
-    pub const NZEN: Balance = 1_000_000_000_000_000_000;
-    pub const CENTS: Balance = NZEN / 100;
-    pub const THOUSANDS: Balance = 1_000 * NZEN;
+    pub const ZETA: Balance = 1_000_000_000_000_000_000;
+    pub const CENTS: Balance = ZETA / 100;
+    pub const THOUSANDS: Balance = 1_000 * ZETA;
     pub const MILLIONS: Balance = 1_000 * THOUSANDS;
 }
 
@@ -213,6 +213,7 @@ impl frame_system::Config for Runtime {
 parameter_types! {
     pub const ExpectedBlockTime: u64 = MILLISECS_PER_BLOCK; // Should use primitives::Moment
     pub const EpochDurationInBlocks: BlockNumber = HOURS; // TODO: use prod_or_fast!
+    
     /// How long (in blocks) an equivocation report is valid for
     pub ReportLongevity: u64 = EpochDurationInBlocks::get() as u64 * 10;
     pub const MaxAuthorities: u32 = 32;
@@ -336,34 +337,23 @@ impl pallet_session::Config for Runtime {
     type WeightInfo = ();
 }
 
-pub struct ZendPayout;
-impl pallet_staking::EraPayout<Balance> for ZendPayout {
-    /// Calculates the validators reward based on the duration of the era.
-    /// The reward mimics the current PoW coinbase (6.25 $ZEN per block).
-    /// Total stake and issuance are currently ignored.
-    fn era_payout(
-        _total_staked: Balance,
-        _total_issuance: Balance,
-        era_duration_millis: u64,
-    ) -> (Balance, Balance) {
-        const HORIZEN_POW_MILLISECS_PER_BLOCK: u128 = 150 * 1000; // 2.5 minutes
-        let era_reward: u128 =
-            625 * CENTS * u128::from(era_duration_millis) / HORIZEN_POW_MILLISECS_PER_BLOCK; // 6.25nZEN per Zend block
-
-        // Assign 100% of the reward to validators.
-        // In the future we may want to split the reward between validators and the treasury.
-        const TENTH_TO_MINERS: u128 = 10;
-        const TENTH_TO_REST: u128 = 0;
-
-        (
-            era_reward * TENTH_TO_MINERS / 10,
-            era_reward * TENTH_TO_REST / 10,
-        )
-    }
+//TODO: Set these parameters appropriately.
+pallet_staking_reward_curve::build! {
+	const REWARD_CURVE: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+		min_inflation: 0_025_000,
+		max_inflation: 0_100_000,
+		ideal_stake: 0_500_000,
+		falloff: 0_050_000,
+		max_piece_count: 40,
+		test_precision: 0_005_000,
+	);
 }
 
 parameter_types! {
     pub const SessionsPerEra: sp_staking::SessionIndex = 6 * HOURS / EpochDurationInBlocks::get(); // number of sessions in 1 era, 6h
+
+    pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear<'static> = &REWARD_CURVE;
+
     pub const BondingDuration: sp_staking::EraIndex = 1; // number of sessions for which staking
                                                          // remains locked
     pub const SlashDeferDuration: sp_staking::EraIndex = 0; // eras to wait before slashing is
@@ -414,7 +404,7 @@ impl pallet_staking::Config for Runtime {
     /// A super-majority of the council can cancel the slash.
     type AdminOrigin = EnsureRoot<AccountId>;
     type SessionInterface = Self;
-    type EraPayout = ZendPayout; // Just an example, we probably should use pallet_staking::ConvertCurve<RewardCurve>;
+    type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;
     type NextNewSession = Session;
     type OffendingValidatorsThreshold = OffendingValidatorsThreshold; // Exceeding this threshold would force a new era
     type ElectionProvider = OnChainExecution<OnChainSeqPhragmen>;

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -560,43 +560,36 @@ mod pallets_interact {
 mod payout {
     use pallet_staking::EraPayout;
 
-    use crate::{Balance, Runtime, CENTS};
+    use crate::{Balance, Runtime};
 
     use super::new_test_ext;
 
-    /// Test that validators receive a cumulative reward that mimics the current emission of
-    /// $ZEN in the PoW Horizen blockchain for miners, which is a coinbase of 6.25 Zen for
-    /// each block every 2.5 minutes.
+    #[ignore]
     #[test]
-    fn is_same_as_pow_coinbase() {
+    fn check_era_rewards() {
         new_test_ext().execute_with(|| {
-            const POW_BLOCK_TIME_MILLIS: u64 = 150 * 1000;
-            const POW_BLOCK_COINBASE: Balance = 625 * CENTS;
+            const ERA_DURATION_MILLIS: u64 = 6 * 60 * 60 * 1000;
+            const TOTAL_STAKED: Balance = 900000000;
+            const TOTAL_ISSUANCE: Balance = 1000000000;
 
-            // Check the reward for an era lasting the target time.
+            // Check the reward for an empty era.
             assert_eq!(
                 <Runtime as pallet_staking::Config>::EraPayout::era_payout(
                     0,
                     0,
-                    POW_BLOCK_TIME_MILLIS
+                    ERA_DURATION_MILLIS
                 ),
-                (POW_BLOCK_COINBASE, 0)
+                (0u128, 0)
             );
 
-            // Check the reward also for a smaller era (it should be proportional).
+            // Check the reward for a normal era
             assert_eq!(
                 <Runtime as pallet_staking::Config>::EraPayout::era_payout(
-                    0,
-                    0,
-                    POW_BLOCK_TIME_MILLIS / 10
+                    TOTAL_STAKED,
+                    TOTAL_ISSUANCE,
+                    ERA_DURATION_MILLIS
                 ),
-                (POW_BLOCK_COINBASE / 10, 0)
-            );
-
-            // Check the reward also for an empty era.
-            assert_eq!(
-                <Runtime as pallet_staking::Config>::EraPayout::era_payout(0, 0, 0),
-                (0, 0)
+                (17313, 51133)
             );
         });
     }

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -564,7 +564,6 @@ mod payout {
 
     use super::new_test_ext;
 
-    #[ignore]
     #[test]
     fn check_era_rewards() {
         new_test_ext().execute_with(|| {


### PR DESCRIPTION
As per title.
Inflation curve parameters have been taken from Polkadot, we'd need to customize them according to our needs in future releases.
All the code and tests related to the simulation of ZEND payouts have been removed.
CDK aggregator address has been removed as well from the chainspec.
Ticker name has been changed to ZETA.
Balances have been updated to sum to around 1B