### PR TITLE
Node key file is now copied to specific directory

### DIFF
--- a/docker/resources/envs/.env.local
+++ b/docker/resources/envs/.env.local
@@ -1,5 +1,7 @@
 # RUST_LOG=debug
 
+NH_NODE_KEY_FILE="/data/config/node_key.dat"
+
 # Node config
 NH_CONF_NAME="RpcNode"
 NH_CONF_BASE_PATH="/data/node"
@@ -7,4 +9,3 @@ NH_CONF_RPC_EXTERNAL="true"
 NH_CONF_CHAIN="local"
 NH_CONF_RPC_CORS="all"
 NH_CONF_PRUNING="archive"
-NH_CONF_NODE_KEY_FILE="/data/config/node_key.dat"

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -63,6 +63,8 @@ echo "NH_NODE=${NH_NODE}"
 
 NH_SECRET_PHRASE_PATH=${NH_SECRET_PHRASE_PATH:-"/data/config/secret_phrase.dat"}
 echo "NH_SECRET_PHRASE_PATH=${NH_SECRET_PHRASE_PATH}"
+NH_NODE_KEY_FILE=${NH_NODE_KEY_FILE:-"/data/config/node_key.dat"}
+echo "NH_NODE_KEY_FILE=${NH_NODE_KEY_FILE}"
 
 # Node configurations (env->arg)
 prefix="NH_CONF_"
@@ -109,6 +111,17 @@ if [ -f "${NH_SECRET_PHRASE_PATH}" ]; then
     --scheme Sr25519 \
     --suri "${NH_SECRET_PHRASE_PATH}" \
     --key-type imon
+fi
+
+# Node-key handling
+if [[ (-n "${NH_CONF_BASE_PATH:-}") && (-n "${NH_CONF_CHAIN:-}") && (-f "${NH_NODE_KEY_FILE}") ]]; then
+  base_path=("$(get_arg_value_from_env_value "${NH_CONF_BASE_PATH}")")
+  chain=("$(get_arg_value_from_env_value "${NH_CONF_CHAIN}")")
+  chain_id=$("${NH_NODE}" build-spec --chain "${chain}" 2> /dev/null | grep \"id\": | awk -F'"' '{print $4}')
+  destination="${base_path}/chains/${chain_id}/network"
+  mkdir -p "${destination}"
+  echo "Copying node key file"
+  cp "${NH_NODE_KEY_FILE}" "${destination}/secret_ed25519"
 fi
 
 echo "Launching ${NH_NODE} with args ${conf_args[*]}"


### PR DESCRIPTION
The copied file is then automatically used by the node

This PR is motivated by this:
Currently, for secret-phrase, at first startup there's a key injection based on the mounted secret-phrase and from here on the node will use the keys and not the secret-phrase; hence it is totally fine to remove the secret-phrase file (from the host machine as well as from the container) without breaking anything; if the secret-phrase is kept and mounted at a second startup, the reinjection is pointless (doesn't occur at all or just rewrite the keys with identical value; no matter).
**Currently, for node-key file, it must always be provided at any startup as a mounted volume. The node itself targets the file through arg `--node-key-file`; with this PR the file gets copied in the proper location and no arg is passed to `nh-node`, because the copied file is automatically selected by the node itself; hence it is totally fine to remove the node-key file (from the host machine as well as from the container).**

**This PR has nothing to do with safe secrets handling (encryption) on container-side, it is just for allowing removal of host-side secrets file (which are still inspectable on container side).**